### PR TITLE
feat: add support for one-command installation via curl/wget

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,15 @@ To enable it, simply append `--classic` (or `--no-nerdfont` / `--compatibility`)
 Choose the installation command for your operating system:
 
 ### 🐧 macOS / Linux
-Run this one-liner to clone the repository to a temporary directory, ensure the installer is executable, run the installer, and automatically clean up the temporary folder:
+
+**One-liner (curl):**
 ```bash
-git clone https://github.com/weby-homelab/antigravity-cli-statusline.git /tmp/antigravity-cli-statusline && chmod +x /tmp/antigravity-cli-statusline/install.sh && /tmp/antigravity-cli-statusline/install.sh && rm -rf /tmp/antigravity-cli-statusline
+curl -fsSL https://raw.githubusercontent.com/weby-homelab/antigravity-cli-statusline/main/install.sh | bash
+```
+
+**One-liner (wget):**
+```bash
+wget -qO- https://raw.githubusercontent.com/weby-homelab/antigravity-cli-statusline/main/install.sh | bash
 ```
 
 **Manual Installation:**
@@ -82,9 +88,16 @@ git clone https://github.com/weby-homelab/antigravity-cli-statusline.git /tmp/an
 ---
 
 ### 🪟 Windows (PowerShell)
-Run this one-liner in PowerShell (run as Administrator if your execution policy is restricted) to install and automatically clean up the temporary directory:
+
+**One-liner (PowerShell WebRequest):**
 ```powershell
-git clone https://github.com/weby-homelab/antigravity-cli-statusline.git $env:TEMP/antigravity-cli-statusline; Powershell -NoProfile -ExecutionPolicy Bypass -File $env:TEMP/antigravity-cli-statusline/install.ps1; Remove-Item -Recurse -Force $env:TEMP/antigravity-cli-statusline
+powershell -NoProfile -ExecutionPolicy Bypass -Command "iex (irm https://raw.githubusercontent.com/weby-homelab/antigravity-cli-statusline/main/install.ps1)"
+```
+
+**One-liner (curl on Windows):**
+If you have curl.exe installed on Windows, you can download and run the installer in one line:
+```powershell
+curl -fsSL https://raw.githubusercontent.com/weby-homelab/antigravity-cli-statusline/main/install.ps1 | powershell -NoProfile -ExecutionPolicy Bypass -Command -
 ```
 
 **Manual Installation:**

--- a/install.ps1
+++ b/install.ps1
@@ -10,22 +10,39 @@ if (-not (Test-Path $installDir)) {
     New-Item -ItemType Directory -Path $installDir | Out-Null
 }
 
-$sourceScript = Join-Path $PSScriptRoot "statusline.ps1"
 $targetScript = Join-Path $installDir "statusline.ps1"
-$sourceUninstall = Join-Path $PSScriptRoot "uninstall.ps1"
 $targetUninstall = Join-Path $installDir "uninstall.ps1"
 
-if (-not (Test-Path $sourceScript)) {
-    Write-Error "Could not find statusline.ps1 in: $PSScriptRoot"
-    exit 1
+$rawUrl = "https://raw.githubusercontent.com/weby-homelab/antigravity-cli-statusline/main"
+
+# Check if we have local files
+$isLocal = $false
+if ($PSScriptRoot) {
+    $sourceScript = Join-Path $PSScriptRoot "statusline.ps1"
+    if (Test-Path $sourceScript) {
+        $isLocal = $true
+    }
 }
 
-Write-Host "Copying statusline.ps1 to $targetScript..."
-Copy-Item -Path $sourceScript -Destination $targetScript -Force
-
-if (Test-Path $sourceUninstall) {
-    Write-Host "Copying uninstall.ps1 to $targetUninstall..."
-    Copy-Item -Path $sourceUninstall -Destination $targetUninstall -Force
+if ($isLocal) {
+    Write-Host "Installing from local files..."
+    $sourceScript = Join-Path $PSScriptRoot "statusline.ps1"
+    $sourceUninstall = Join-Path $PSScriptRoot "uninstall.ps1"
+    
+    Write-Host "Copying statusline.ps1 to $targetScript..."
+    Copy-Item -Path $sourceScript -Destination $targetScript -Force
+    
+    if (Test-Path $sourceUninstall) {
+        Write-Host "Copying uninstall.ps1 to $targetUninstall..."
+        Copy-Item -Path $sourceUninstall -Destination $targetUninstall -Force
+    }
+} else {
+    Write-Host "Installing from remote repository..."
+    Write-Host "Downloading statusline.ps1..."
+    Invoke-WebRequest -Uri "$rawUrl/statusline.ps1" -OutFile $targetScript -UseBasicParsing
+    
+    Write-Host "Downloading uninstall.ps1..."
+    Invoke-WebRequest -Uri "$rawUrl/uninstall.ps1" -OutFile $targetUninstall -UseBasicParsing
 }
 
 # Configuration file

--- a/install.sh
+++ b/install.sh
@@ -30,24 +30,42 @@ INSTALL_DIR="$HOME/.antigravity"
 echo -e "Creating directory ${INSTALL_DIR}..."
 mkdir -p "$INSTALL_DIR"
 
-# 3. Copy files
-SCRIPT_SOURCE="$(dirname "$0")/statusline.sh"
+# 3. Copy/Download files
 SCRIPT_TARGET="${INSTALL_DIR}/statusline.sh"
-UNINSTALL_SOURCE="$(dirname "$0")/uninstall.sh"
 UNINSTALL_TARGET="${INSTALL_DIR}/uninstall.sh"
 
-if [ ! -f "$SCRIPT_SOURCE" ]; then
-  echo -e "${RED}Error: Cannot find statusline.sh in $(dirname "$0")${RESET}"
-  exit 1
+LOCAL_DIR=""
+if [ -f "$(dirname "$0")/statusline.sh" ]; then
+  LOCAL_DIR="$(dirname "$0")"
 fi
 
-echo -e "Copying statusline.sh to ${SCRIPT_TARGET}..."
-cp "$SCRIPT_SOURCE" "$SCRIPT_TARGET"
-chmod +x "$SCRIPT_TARGET"
+RAW_URL="https://raw.githubusercontent.com/weby-homelab/antigravity-cli-statusline/main"
 
-if [ -f "$UNINSTALL_SOURCE" ]; then
-  echo -e "Copying uninstall.sh to ${UNINSTALL_TARGET}..."
-  cp "$UNINSTALL_SOURCE" "$UNINSTALL_TARGET"
+if [ -n "$LOCAL_DIR" ]; then
+  echo -e "Installing from local files..."
+  cp "${LOCAL_DIR}/statusline.sh" "$SCRIPT_TARGET"
+  chmod +x "$SCRIPT_TARGET"
+  if [ -f "${LOCAL_DIR}/uninstall.sh" ]; then
+    cp "${LOCAL_DIR}/uninstall.sh" "$UNINSTALL_TARGET"
+    chmod +x "$UNINSTALL_TARGET"
+  fi
+else
+  echo -e "Installing from remote repository..."
+  if command -v curl &> /dev/null; then
+    echo -e "Downloading statusline.sh using curl..."
+    curl -fsSL "${RAW_URL}/statusline.sh" -o "$SCRIPT_TARGET"
+    echo -e "Downloading uninstall.sh using curl..."
+    curl -fsSL "${RAW_URL}/uninstall.sh" -o "$UNINSTALL_TARGET"
+  elif command -v wget &> /dev/null; then
+    echo -e "Downloading statusline.sh using wget..."
+    wget -qO "$SCRIPT_TARGET" "${RAW_URL}/statusline.sh"
+    echo -e "Downloading uninstall.sh using wget..."
+    wget -qO "$UNINSTALL_TARGET" "${RAW_URL}/uninstall.sh"
+  else
+    echo -e "${RED}Error: Neither curl nor wget is installed. Cannot download files.${RESET}"
+    exit 1
+  fi
+  chmod +x "$SCRIPT_TARGET"
   chmod +x "$UNINSTALL_TARGET"
 fi
 


### PR DESCRIPTION
This PR adds support for installing the statusline plugin with a single command on Linux, macOS, and Windows. When running directly from the web (via curl/wget | bash or PowerShell iex), the installers will dynamically download the required script files directly from GitHub. It also updates the README.md with the new installation commands.