### PR TITLE
feat: prevent running installer with sudo

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,16 @@ YELLOW='\033[0;33m'
 BLUE='\033[0;34m'
 RESET='\033[0m'
 
+# Check if running via sudo
+if [ -n "${SUDO_USER:-}" ]; then
+  echo -e "${RED}Error: This script should NOT be run with sudo or as root via sudo.${RESET}"
+  echo -e "${YELLOW}The statusline installs locally in your home directory (~/.antigravity).${RESET}"
+  echo -e "${YELLOW}Running with sudo will cause file permission issues for your user account.${RESET}"
+  echo -e "Please run the installation command without sudo:"
+  echo -e "${GREEN}curl -fsSL https://raw.githubusercontent.com/weby-homelab/antigravity-cli-statusline/main/install.sh | bash${RESET}"
+  exit 1
+fi
+
 echo -e "${BLUE}====================================================${RESET}"
 echo -e "${GREEN}  Installing Antigravity CLI Statusline (Linux/Mac) ${RESET}"
 echo -e "${BLUE}====================================================${RESET}"


### PR DESCRIPTION
This PR adds a safety check to install.sh. If running via sudo (SUDO_USER is defined), it prevents installation and warns the user to run without sudo. This prevents changing user-home configuration file permissions to root, which would break the statusline and general config modifications for the normal user.