### PR TITLE
Fix dual language rendering on load

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -46,7 +46,7 @@
   }
   </script>
 </head>
-<body>
+<body class="lang-en">
 
   <!-- Navigation Header -->
   <header>

--- a/website/style.css
+++ b/website/style.css
@@ -1038,3 +1038,9 @@ body.lang-ua .lang-en {
   display: none !important;
 }
 
+/* Fallback: if body has neither class, default to hiding UA */
+body:not(.lang-ua):not(.lang-en) .lang-ua {
+  display: none !important;
+}
+
+


### PR DESCRIPTION
Closes #17. Sets default body class to lang-en and adds uninitialized CSS fallback rules to prevent dual language text overlap.