### PR TITLE
Support responsive 2-line layout on scaled terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,14 @@ An advanced, responsive, and high-information statusline plugin for the **[Antig
 The ultimate high-information layout displaying all telemetry fields: system metrics, Git status, active subagents, background tasks, model quotas, and power/battery state in a single aligned row.
 ![Ultra Layout](screenshots/Antigravity-cli-statusline-ULTRA-2.png)
 
-### 📱 Medium Layout (Terminal width 130 to 179 chars)
-Stacks status and telemetry into a clean 3-line layout to prevent command output wrapping on standard terminals.
+### ⚡ Medium-Wide / Two-Line Layout (Terminal width 140 to 179 chars)
+Encloses the statusline powerline segments and all telemetry badges into a space-efficient, beautifully boxed 2-line layout.
+
+### 📱 Medium Layout (Terminal width 100 to 139 chars)
+Stacks status segments and telemetry badges into a clean 3-line layout to prevent command output wrapping on standard terminals.
 ![Medium Layout](screenshots/Antigravity-cli-statusline-MEDIUM-2.png)
 
-### 📟 Small / Compact Layout (Terminal width < 130 chars)
+### 📟 Small / Compact Layout (Terminal width < 100 chars)
 Ensures all metrics (READY, model, CWD, tokens, resources, and power) fit perfectly in a stacked 4-line layout on narrower terminals.
 ![Compact Layout](screenshots/Antigravity-cli-statusline-SMALL-2.png)
 
@@ -249,6 +252,10 @@ Your `%USERPROFILE%\.gemini\antigravity-cli\settings.json` will be configured as
 ---
 
 ## 📝 Important Notes & Release History
+
+### 🚀 Release v0.1.5 (July 9, 2026)
+- **Responsive 2-Line Layout**: Configured a space-efficient 2-line layout when the terminal window is scaled between 140 and 179 characters wide.
+- **Optimized Tokens Display**: Split token usage formatting into wide and medium versions to prevent terminal output wrapping on compact displays.
 
 ### 🚀 Release v0.1.4 (July 8, 2026)
 - **Git Timeout Resilience**: Added a 1-second timeout wrapper around all Git calls to prevent terminal statusline hangs on slow, unreachable network mounts (NFS, Samba) or extremely large repositories.

--- a/statusline.sh
+++ b/statusline.sh
@@ -120,8 +120,9 @@ for arg in "$@"; do
       echo -e ""
       echo -e "${B}LAYOUTS:${R}"
       echo -e "  - ${B}Wide Layout (>= 180 chars):${R} Single-row powerline segment dashboard."
-      echo -e "  - ${B}Medium Layout (>= 90 chars):${R} Double-line boxed telemetry block."
-      echo -e "  - ${B}Small Layout (< 90 chars):${R} Minimalist indicator for status, model & resources."
+      echo -e "  - ${B}Medium-Wide Layout (140-179 chars):${R} Double-line boxed telemetry block."
+      echo -e "  - ${B}Medium Layout (100-139 chars):${R} Triple-line boxed telemetry block."
+      echo -e "  - ${B}Small Layout (< 100 chars):${R} Quad-line stacked telemetry dashboard."
       echo -e ""
       echo -e "${B}COMPONENTS & ICONS:${R}"
       echo -e "  ${B}Field                Nerd Font   Classic     Description${R}"
@@ -693,16 +694,19 @@ if [ -n "$AC_ONLINE_PATH" ]; then
 fi
 
 # Token counters
-TOK_DETAILS=""
+TOK_DETAILS_WIDE=""
+TOK_DETAILS_MED=""
 if [ "$CTX_USED" -gt 0 ] 2>/dev/null; then
   turn_str=""
   if [ "$TURN_INPUT_TOKENS" -gt 0 ] || [ "$TURN_OUTPUT_TOKENS" -gt 0 ]; then
     turn_str=" | turn: +${TURN_INPUT_FMT}/${TURN_OUTPUT_FMT}"
   fi
   if [ "$USE_CLASSIC_ICONS" = "true" ]; then
-    TOK_DETAILS=" (${CTX_USED_FMT}/${CTX_LIMIT_FMT})${DOT_L2}(total: ${INPUT_TOK_FMT}/${OUTPUT_TOK_FMT}${turn_str})"
+    TOK_DETAILS_WIDE=" (${CTX_USED_FMT}/${CTX_LIMIT_FMT})${DOT_L2}(total: ${INPUT_TOK_FMT}/${OUTPUT_TOK_FMT}${turn_str})"
+    TOK_DETAILS_MED=" (${CTX_USED_FMT}/${CTX_LIMIT_FMT})"
   else
-    TOK_DETAILS=" (${CTX_USED_FMT}/${CTX_LIMIT_FMT})${DOT_L2}${FG_YELLOW}${ICON_TOK_SUM} ${R} (total: ${INPUT_TOK_FMT}/${OUTPUT_TOK_FMT}${turn_str})"
+    TOK_DETAILS_WIDE=" (${CTX_USED_FMT}/${CTX_LIMIT_FMT})${DOT_L2}${FG_YELLOW}${ICON_TOK_SUM} ${R} (total: ${INPUT_TOK_FMT}/${OUTPUT_TOK_FMT}${turn_str})"
+    TOK_DETAILS_MED=" (${CTX_USED_FMT}/${CTX_LIMIT_FMT})"
   fi
 fi
 
@@ -831,15 +835,29 @@ if [ "$COLS" -ge 180 ]; then
   # Wide Layout: single row, left segment block and right pill dashboard
   LINE2=""
   if [ -n "$SYS_FMT" ]; then LINE2="${SYS_FMT}${sep}"; fi
-  LINE2="${LINE2}${ART_FMT}${sep}${SUB_FMT}${sep}${BG_FMT}${sep}${SB_FMT}${sep}${CTX_BAR}${TOK_DETAILS}"
+  LINE2="${LINE2}${ART_FMT}${sep}${SUB_FMT}${sep}${BG_FMT}${sep}${SB_FMT}${sep}${CTX_BAR}${TOK_DETAILS_WIDE}"
   if [ -n "$QUOTA_FMT" ]; then LINE2="${LINE2} ${QUOTA_FMT}"; fi
   if [ -n "$POWER_FMT" ]; then LINE2="${LINE2}${sep}${POWER_FMT}"; fi
   
   print_right_aligned "$LINE1" "$LINE2" "$COLS"
 
-elif [ "$COLS" -ge 130 ]; then
+elif [ "$COLS" -ge 140 ]; then
+  # Medium-Wide Layout: 2-line boxed display
+  LINE2="${CTX_BAR}${TOK_DETAILS_MED}"
+  for badge in "$SYS_FMT" "$ART_FMT" "$SUB_FMT" "$BG_FMT" "$SB_FMT"; do
+    if [ -n "$badge" ]; then
+      LINE2="${LINE2}${sep}${badge}"
+    fi
+  done
+  if [ -n "$QUOTA_FMT" ]; then LINE2="${LINE2}${sep}${QUOTA_FMT}"; fi
+  if [ -n "$POWER_FMT" ]; then LINE2="${LINE2}${sep}${POWER_FMT}"; fi
+  
+  echo -e "${line_pref1}${LINE1}"
+  echo -e "${line_pref4}${LINE2}"
+
+elif [ "$COLS" -ge 100 ]; then
   # Medium Layout: 3-row display to avoid wrapping
-  LINE2="${CTX_BAR}${TOK_DETAILS}"
+  LINE2="${CTX_BAR}${TOK_DETAILS_MED}"
   for badge in "$SYS_FMT" "$ART_FMT" "$SUB_FMT" "$BG_FMT" "$SB_FMT"; do
     if [ -n "$badge" ]; then
       LINE2="${LINE2}${sep}${badge}"
@@ -863,8 +881,8 @@ elif [ "$COLS" -ge 130 ]; then
   fi
 
 else
-  # Compact Layout: 4-row display ensuring all blocks are visible and fit perfectly
-  LINE2="${CTX_BAR}${TOK_DETAILS}"
+  # Compact Layout: 4-row display ensuring all blocks fit perfectly
+  LINE2="${CTX_BAR}${TOK_DETAILS_MED}"
   
   LINE3=""
   for badge in "$SYS_FMT" "$ART_FMT" "$SUB_FMT" "$BG_FMT" "$SB_FMT"; do


### PR DESCRIPTION
Implements a space-efficient 2-line layout when terminal width is scaled between 140 and 179 characters wide, and splits tokens details into wide and medium versions to prevent line wrapping.