### PR TITLE
fix: preserve settings.json symlinks during install and uninstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.7] - 2026-07-13
+### Fixed
+- **Symlink Preservation**: Modified installers and uninstallers (`install.sh`, `uninstall.sh`, and `uninstall.ps1`) to avoid breaking symlinks when updating `settings.json`. Instead of using `mv`/`Move-Item` which replaces whole files, the scripts now use redirection (`cat > file`) and copying (`Copy-Item` / `Remove-Item`) to perform disjoint-key updates directly on the target configurations. This prevents breaking user setups managed by dotfile managers (like chezmoi, stow, or custom symlinked setups).

--- a/install.sh
+++ b/install.sh
@@ -91,7 +91,8 @@ if [ -f "$SETTINGS_FILE" ]; then
 
   # Merge using jq
   jq '.statusLine = { "type": "", "command": "'"${SCRIPT_TARGET}"'", "enabled": true }' "$SETTINGS_FILE" > "${SETTINGS_FILE}.tmp"
-  mv "${SETTINGS_FILE}.tmp" "$SETTINGS_FILE"
+  cat "${SETTINGS_FILE}.tmp" > "$SETTINGS_FILE"
+  rm -f "${SETTINGS_FILE}.tmp"
 else
   # Create directory if missing
   mkdir -p "$SETTINGS_DIR"

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -18,7 +18,8 @@ $settingsFile = "$HOME\.gemini\antigravity-cli\settings.json"
 if (Test-Path $settingsFile) {
     if (Test-Path "${settingsFile}.bak") {
         Write-Host "Restoring backup settings from ${settingsFile}.bak..."
-        Move-Item -Path "${settingsFile}.bak" -Destination $settingsFile -Force
+        Copy-Item -Path "${settingsFile}.bak" -Destination $settingsFile -Force
+        Remove-Item -Path "${settingsFile}.bak" -Force
     } else {
         Write-Host "Disabling statusLine in settings.json..."
         $json = Get-Content -Raw -Path $settingsFile | ConvertFrom-Json

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -29,12 +29,14 @@ if [ -f "$SETTINGS_FILE" ]; then
   # If a backup exists, restore it
   if [ -f "${SETTINGS_FILE}.bak" ]; then
     echo -e "Restoring backup settings from ${SETTINGS_FILE}.bak..."
-    mv "${SETTINGS_FILE}.bak" "$SETTINGS_FILE"
+    cat "${SETTINGS_FILE}.bak" > "$SETTINGS_FILE"
+    rm -f "${SETTINGS_FILE}.bak"
   else
     if command -v jq &> /dev/null; then
       # Turn off statusLine configuration
       jq '.statusLine.enabled = false' "$SETTINGS_FILE" > "${SETTINGS_FILE}.tmp"
-      mv "${SETTINGS_FILE}.tmp" "$SETTINGS_FILE"
+      cat "${SETTINGS_FILE}.tmp" > "$SETTINGS_FILE"
+      rm -f "${SETTINGS_FILE}.tmp"
       echo -e "Set statusLine.enabled to false."
     else
       echo -e "${YELLOW}Warning: 'jq' not found. Please manually set 'statusLine.enabled: false' in ${SETTINGS_FILE}${RESET}"


### PR DESCRIPTION
Fixes #48 by writing to the config file directly rather than replacing it with a new file, keeping symlinks intact.