### PR TITLE
FIX: resolve decimal format error and battery detection crash under macOS

### DIFF
--- a/statusline.sh
+++ b/statusline.sh
@@ -3,6 +3,7 @@
 # Built with premium 256-color powerline theme & instant system diagnostics
 
 set -euo pipefail
+export LC_NUMERIC=C
 INPUT_JSON=$(cat)
 
 # ─── ANSI Helpers (Standard colors) ───────────────────────────────────────────
@@ -375,8 +376,12 @@ fi
 
 # ─── Power / Battery Scanner ─────────────────────────────────────────────────
 POWER_FMT=""
-AC_ONLINE_PATH=$(ls /sys/class/power_supply/*/online 2>/dev/null | head -n 1)
-BAT_CAP_PATH=$(ls /sys/class/power_supply/*/capacity 2>/dev/null | head -n 1)
+AC_ONLINE_PATH=""
+BAT_CAP_PATH=""
+if [ -d /sys/class/power_supply ]; then
+  AC_ONLINE_PATH=$(ls /sys/class/power_supply/*/online 2>/dev/null | head -n 1 || true)
+  BAT_CAP_PATH=$(ls /sys/class/power_supply/*/capacity 2>/dev/null | head -n 1 || true)
+fi
 
 # ─── Segment powerline formatter ──────────────────────────────────────────────
 make_segment() {


### PR DESCRIPTION
This PR fixes statusline errors on macOS.

1. Exposing LC_NUMERIC=C forces the shell built-in printf to use dot decimal format, preventing invalid number errors.
2. Guarding battery directory check ensures the script doesn't crash on macOS where power_supply path doesn't exist.