### PR TITLE
fix: remove invalid 'local' keyword from global scope

### DIFF
--- a/statusline.sh
+++ b/statusline.sh
@@ -685,7 +685,7 @@ if [ -n "$AC_ONLINE_PATH" ]; then
   fi
   
   if [ "$AC_ON" = "0" ]; then
-    local label="BAT"
+    label="BAT"
     if [ -n "$BAT_CAP" ]; then
       label="${BAT_CAP}%"
     fi


### PR DESCRIPTION
*The Issue*
On battery-powered devices (laptops/Chromebooks), the statusline script crashes with local: can only be used in a function because local label="BAT" is used inside the global scope.

*The Bug's Flaky Behavior*
• On Desktop (e.g., Chromebox): No battery exists, so the battery block is never entered or evaluated (meaning no crash).
• On Laptop (Battery): Enters the battery block and crashes.
• On Laptop (Plugged In): Bypasses the battery block, causing the error to disappear.

*The Fix*
Removed local from line 688 so label is declared as a standard variable.