### PR TITLE
feat(statusline): display used tokens and context window size in ctx badge (v0.2.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.3] - 2026-08-13
+## [0.2.3] - 2026-09-03
+### Added & Improved
+- **Context Window & Token Usage Display**: Added token usage and context window limit metrics `(${CTX_USED_FMT}/${CTX_LIMIT_FMT})` directly into the `ctx` badge across both classic ANSI and 256-color pill layouts in `statusline.sh` and `statusline.ps1`.
+- **Accurate Context Metric Extraction**: Fixed context usage calculation to accurately track active context window tokens (`total_input_tokens`) and added fallback calculation for context window size when missing.
+- **Enhanced Human Format Rounding**: Improved `human_format` rounding for `K` and `M` token metrics.
+
 ### Fixed & Hardened
 - **Blocked Stdin Timeout Protection**: Added `run_with_timeout 0.25 cat` stdin timeout guard and immediate `exec 0</dev/null` in `statusline.sh` (and asynchronous `Task` timeout in `statusline.ps1`). Prevents the statusline script from hanging indefinitely during OAuth refresh, authentication, or conversation warm-up when `antigravity-cli` holds stdin open without sending data, avoiding hard SIGKILL shutdowns and plugin auto-disablement.
 

--- a/statusline.ps1
+++ b/statusline.ps1
@@ -101,7 +101,10 @@ $TURN_OUTPUT_TOKENS = if ($data.context_window.current_usage.output_tokens -ne $
 $INPUT_TOKENS = if ($data.context_window.total_input_tokens -ne $null) { $data.context_window.total_input_tokens } else { 0 }
 $OUTPUT_TOKENS = if ($data.context_window.total_output_tokens -ne $null) { $data.context_window.total_output_tokens } else { 0 }
 $CTX_LIMIT = if ($data.context_window.context_window_size -ne $null) { $data.context_window.context_window_size } else { 0 }
-$CTX_USED = $INPUT_TOKENS + $OUTPUT_TOKENS
+$CTX_USED = if ($data.context_window.total_tokens -ne $null) { $data.context_window.total_tokens } elseif ($INPUT_TOKENS -gt 0) { $INPUT_TOKENS } else { $INPUT_TOKENS + $OUTPUT_TOKENS }
+if (($CTX_LIMIT -eq 0 -or $CTX_LIMIT -eq $null) -and $CTX_USED -gt 0 -and $USED_PCT -gt 0) {
+    $CTX_LIMIT = [int][Math]::Floor($CTX_USED * 100 / $USED_PCT)
+}
 $REM_PCT = if ($data.context_window.remaining_percentage -ne $null) { $data.context_window.remaining_percentage } else { 100 }
 
 # Quotas
@@ -442,7 +445,13 @@ if ($USE_CLASSIC_ICONS) {
             $BAR += "·"
         }
     }
-    $CTX_BAR = "${FG_GRAY}ctx ${FILL_COLOR}${BAR} ${NUM_COLOR}${PCT_FMT}%${R}"
+    if ($CTX_LIMIT -gt 0) {
+        $CTX_BAR = "${FG_GRAY}ctx ${FILL_COLOR}${BAR} ${NUM_COLOR}${PCT_FMT}%${R} ${FG_GRAY}(${CTX_USED_FMT}/${CTX_LIMIT_FMT})${R}"
+    } elseif ($CTX_USED -gt 0) {
+        $CTX_BAR = "${FG_GRAY}ctx ${FILL_COLOR}${BAR} ${NUM_COLOR}${PCT_FMT}%${R} ${FG_GRAY}(${CTX_USED_FMT})${R}"
+    } else {
+        $CTX_BAR = "${FG_GRAY}ctx ${FILL_COLOR}${BAR} ${NUM_COLOR}${PCT_FMT}%${R}"
+    }
 } else {
     $BAR = ""
     for ($i = 0; $i -lt $BAR_LEN; $i++) {
@@ -456,7 +465,13 @@ if ($USE_CLASSIC_ICONS) {
             $BAR += "${FG_GRAY}░${R}"
         }
     }
-    $CTX_BAR = "${FG_YELLOW}${ICON_CONTEXT_BAR}  ${R}${BAR} ${NUM_COLOR}${PCT_FMT}%${R}"
+    if ($CTX_LIMIT -gt 0) {
+        $CTX_BAR = "${FG_YELLOW}${ICON_CONTEXT_BAR}  ${R}${BAR} ${NUM_COLOR}${PCT_FMT}%${R} ${FG_GRAY}(${CTX_USED_FMT}/${CTX_LIMIT_FMT})${R}"
+    } elseif ($CTX_USED -gt 0) {
+        $CTX_BAR = "${FG_YELLOW}${ICON_CONTEXT_BAR}  ${R}${BAR} ${NUM_COLOR}${PCT_FMT}%${R} ${FG_GRAY}(${CTX_USED_FMT})${R}"
+    } else {
+        $CTX_BAR = "${FG_YELLOW}${ICON_CONTEXT_BAR}  ${R}${BAR} ${NUM_COLOR}${PCT_FMT}%${R}"
+    }
 }
 
 # Stats badges

--- a/statusline.sh
+++ b/statusline.sh
@@ -161,7 +161,7 @@ NUM_COLOR="${FG_BRIGHT_WHITE}${B}"
     (.context_window.total_input_tokens // 0),
     (.context_window.total_output_tokens // 0),
     (.context_window.context_window_size // 0),
-    ((.context_window.total_input_tokens // 0) + (.context_window.total_output_tokens // 0)),
+    (.context_window.total_tokens // (if (.context_window.total_input_tokens // 0) > 0 then .context_window.total_input_tokens else ((.context_window.total_input_tokens // 0) + (.context_window.total_output_tokens // 0)) end)),
     (.context_window.remaining_percentage // 100),
     (if .quota["gemini-5h"].remaining_fraction != null then ((.quota["gemini-5h"].remaining_fraction * 1000 | round) / 10) else -1 end),
     (if .quota["gemini-weekly"].remaining_fraction != null then ((.quota["gemini-weekly"].remaining_fraction * 1000 | round) / 10) else -1 end),
@@ -191,6 +191,13 @@ if ! [[ "$INPUT_TOKENS" =~ ^[0-9]+$ ]]; then INPUT_TOKENS=0; fi
 if ! [[ "$OUTPUT_TOKENS" =~ ^[0-9]+$ ]]; then OUTPUT_TOKENS=0; fi
 if ! [[ "$CTX_LIMIT" =~ ^[0-9]+$ ]]; then CTX_LIMIT=0; fi
 if ! [[ "$CTX_USED" =~ ^[0-9]+$ ]]; then CTX_USED=0; fi
+if [ "$CTX_LIMIT" -eq 0 ] 2>/dev/null && [ "$CTX_USED" -gt 0 ] 2>/dev/null; then
+  pct_whole=${USED_PCT%.*}
+  pct_whole=${pct_whole:-0}
+  if [ "$pct_whole" -gt 0 ]; then
+    CTX_LIMIT=$(( CTX_USED * 100 / pct_whole ))
+  fi
+fi
 if ! [[ "$TURN_INPUT_TOKENS" =~ ^[0-9]+$ ]]; then TURN_INPUT_TOKENS=0; fi
 if ! [[ "$TURN_OUTPUT_TOKENS" =~ ^[0-9]+$ ]]; then TURN_OUTPUT_TOKENS=0; fi
 
@@ -483,10 +490,10 @@ human_format() {
     echo "0"
     return
   fi
-  if [ "$num" -ge 1000000 ] 2>/dev/null; then
-    echo "$((num / 1000000)).$(((num % 1000000) / 100000))M"
+  if [ "$num" -ge 999500 ] 2>/dev/null; then
+    echo "$(( (num + 50000) / 1000000 )).$((( (num + 50000) % 1000000 ) / 100000 ))M"
   elif [ "$num" -ge 1000 ] 2>/dev/null; then
-    echo "$((num / 1000)).$(((num % 1000) / 100))K"
+    echo "$(( (num + 50) / 1000 )).$((( (num + 50) % 1000 ) / 100 ))K"
   else
     echo "$num"
   fi
@@ -833,7 +840,13 @@ if [ "$USE_CLASSIC_ICONS" = "true" ]; then
     else BAR="${BAR}·"
     fi
   done
-  CTX_BAR="${FG_GRAY}ctx ${FILL_COLOR}${BAR} ${NUM_COLOR}${PCT_FMT}%${R}"
+  if [ "$CTX_LIMIT" -gt 0 ] 2>/dev/null; then
+    CTX_BAR="${FG_GRAY}ctx ${FILL_COLOR}${BAR} ${NUM_COLOR}${PCT_FMT}%${R} ${FG_GRAY}(${CTX_USED_FMT}/${CTX_LIMIT_FMT})${R}"
+  elif [ "$CTX_USED" -gt 0 ] 2>/dev/null; then
+    CTX_BAR="${FG_GRAY}ctx ${FILL_COLOR}${BAR} ${NUM_COLOR}${PCT_FMT}%${R} ${FG_GRAY}(${CTX_USED_FMT})${R}"
+  else
+    CTX_BAR="${FG_GRAY}ctx ${FILL_COLOR}${BAR} ${NUM_COLOR}${PCT_FMT}%${R}"
+  fi
 else
   # Color palette based on context size
   if [ "$PCT_INT" -ge 90 ]; then bar_c="197"; else bar_c="214"; fi
@@ -857,7 +870,13 @@ else
   # Pill badge for Context Bar
   label_bg="236"
   bar_bg="235"
-  CTX_BAR="\033[38;5;${label_bg}m\033[48;5;${label_bg}m\033[38;5;220m${ICON_CONTEXT_BAR} ctx\033[48;5;${bar_bg}m ${BAR}\033[48;5;${label_bg}m \033[38;5;220m\033[1m${PCT_FMT}%\033[0m\033[38;5;${label_bg}m\033[0m"
+  if [ "$CTX_LIMIT" -gt 0 ] 2>/dev/null; then
+    CTX_BAR="\033[38;5;${label_bg}m\033[48;5;${label_bg}m\033[38;5;220m${ICON_CONTEXT_BAR} ctx\033[48;5;${bar_bg}m ${BAR}\033[48;5;${label_bg}m \033[38;5;220m\033[1m${PCT_FMT}%\033[22m \033[38;5;250m(${CTX_USED_FMT}/${CTX_LIMIT_FMT})\033[0m\033[38;5;${label_bg}m\033[0m"
+  elif [ "$CTX_USED" -gt 0 ] 2>/dev/null; then
+    CTX_BAR="\033[38;5;${label_bg}m\033[48;5;${label_bg}m\033[38;5;220m${ICON_CONTEXT_BAR} ctx\033[48;5;${bar_bg}m ${BAR}\033[48;5;${label_bg}m \033[38;5;220m\033[1m${PCT_FMT}%\033[22m \033[38;5;250m(${CTX_USED_FMT})\033[0m\033[38;5;${label_bg}m\033[0m"
+  else
+    CTX_BAR="\033[38;5;${label_bg}m\033[48;5;${label_bg}m\033[38;5;220m${ICON_CONTEXT_BAR} ctx\033[48;5;${bar_bg}m ${BAR}\033[48;5;${label_bg}m \033[38;5;220m\033[1m${PCT_FMT}%\033[0m\033[38;5;${label_bg}m\033[0m"
+  fi
 fi
 
 # ─── Statistics & Telemetry Badges ──────────────────────────────────────────


### PR DESCRIPTION
### Summary of Changes

- **Context Window & Token Usage Display**: Added token usage and context window limit metrics `(${CTX_USED_FMT}/${CTX_LIMIT_FMT})` directly into the `ctx` badge across both classic ANSI and 256-color pill layouts in `statusline.sh` and `statusline.ps1`.
- **Accurate Context Metric Extraction**: Fixed context usage calculation to accurately track active context window tokens (`total_input_tokens`) and added fallback calculation for context window size when missing.
- **Enhanced Human Format Rounding**: Improved `human_format` rounding for `K` and `M` token metrics.
- **Release Version**: Consolidated release v0.2.3 changes in `CHANGELOG.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Context status indicators now display token usage alongside the usage percentage when available.
  * Context limits can be estimated when the source data omits them.
* **Improvements**
  * Context usage tracking now prioritizes reported total token counts and uses fallbacks when needed.
  * Token metrics use more accurate rounding and formatting for thousands and millions.
* **Documentation**
  * Updated the version 0.2.3 changelog with the latest release date and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->