### PR TITLE
fix(packing): prevent premature extra line split on wide terminals (fixes #59)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Enhanced Human Format Rounding**: Improved `human_format` rounding for `K` and `M` token metrics.
 
 ### Fixed & Hardened
+- **Prevent Premature Line Splitting (Issue #59)**: Corrected line-packing boundary check in classic mode to use full terminal width (`max_vis = COLS - 1`) without box-drawing border padding. Optimized wide-bar threshold to 235 columns, eliminating unnecessary line splits and empty row wrapping on wide displays (e.g., 237 columns).
+- **PowerShell Parity & Fixes (PR #58)**: Ported `make_badge` and ANSI color mapper to `statusline.ps1`, restored `$LINE1` concatenation, corrected sandbox reference, and fixed quota bar colors.
 - **Blocked Stdin Timeout Protection**: Added `run_with_timeout 0.25 cat` stdin timeout guard and immediate `exec 0</dev/null` in `statusline.sh` (and asynchronous `Task` timeout in `statusline.ps1`). Prevents the statusline script from hanging indefinitely during OAuth refresh, authentication, or conversation warm-up when `antigravity-cli` holds stdin open without sending data, avoiding hard SIGKILL shutdowns and plugin auto-disablement.
 
 ## [0.2.2] - 2026-07-22

--- a/statusline.ps1
+++ b/statusline.ps1
@@ -446,8 +446,8 @@ if ($SANDBOX -eq $true) {
     }
 }
 
-# Context bar
-$BAR_LEN = 20
+# Context bar (wide bar requires >= 235 cols)
+$BAR_LEN = if ($COLS -ge 235) { 20 } else { 10 }
 $FILLED = [int][Math]::Floor(($PCT_INT * $BAR_LEN) / 100)
 $REMAINDER = ($PCT_INT * $BAR_LEN) % 100
 
@@ -587,7 +587,7 @@ function make_quota_bar($val, $label, $bar_color, $reset_sec) {
     if ($val_int -lt 20) { $text_color = $FG_BRIGHT_RED }
     elseif ($val_int -lt 50) { $text_color = $FG_BRIGHT_YELLOW }
 
-    $bar_len = 20
+    $bar_len = if ($COLS -ge 235) { 15 } else { 8 }
     $filled = [int][Math]::Floor(($val_int * $bar_len) / 100)
     $remainder = ($val_int * $bar_len) % 100
 
@@ -691,7 +691,7 @@ if ($POWER_FMT) { $BADGE_LIST += $POWER_FMT }
 $PACKED_LINES = @()
 $curr_line = ""
 $curr_vis = 0
-$max_vis = $COLS - 4
+$max_vis = if ($USE_CLASSIC_ICONS) { $COLS - 1 } else { $COLS - 4 }
 if ($max_vis -lt 40) { $max_vis = 40 }
 
 foreach ($badge in $BADGE_LIST) {

--- a/statusline.sh
+++ b/statusline.sh
@@ -318,7 +318,8 @@ for arg in "$@"; do
 done
 
 # Set dynamic width boundaries
-if [ "$COLS" -ge 180 ]; then
+# Wide bars (20/15 segments) require >= 235 columns to fit alongside full telemetry without split
+if [ "$COLS" -ge 235 ]; then
   BAR_LEN=20
   QUOTA_BAR_LEN=15
 else
@@ -1131,8 +1132,12 @@ fi
 # Greedy Line-Packing Routine
 PACKED_LINES=()
 curr_line=""
-curr_vis=0
-max_vis=$(( COLS - 4 ))
+# Classic mode lacks box-drawing borders (╭─, ├─, ╰─), so it uses full terminal width
+if [ "$USE_CLASSIC_ICONS" = "true" ]; then
+  max_vis=$(( COLS - 1 ))
+else
+  max_vis=$(( COLS - 4 ))
+fi
 if [ "$max_vis" -lt 40 ]; then max_vis=40; fi
 
 for badge in "${BADGE_LIST[@]}"; do


### PR DESCRIPTION
### Summary of Fix (resolves #59)

- **Prevent Premature Line Splitting**: Corrected line-packing boundary check in classic mode to utilize full terminal width (`max_vis = COLS - 1`) instead of applying the 4-column border penalty used by box-drawing layouts.
- **Optimized Wide Bar Threshold**: Adjusted threshold for 20-segment / 15-segment bars to 235 columns so that terminals around 180–237 columns do not prematurely expand and cause telemetry badges to spill onto an extra line.
- **PowerShell Parity**: Synchronized adaptive bar sizing and `max_vis` calculation in `statusline.ps1`.