### PR TITLE
release: v0.2.5 - Power & AC Supply Detection Hardening (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.5] - 2026-09-11
+### Fixed & Improved
+- **Power & AC Supply Detection Hardening (Issue #70)**:
+  - Resolved bug where the power badge remained stuck on `🔋 BAT` even when connected to external AC mains power or on desktop workstations.
+  - Excluded peripheral devices (`scope: Device`, `hidpp_*`, mice, keyboards) from overriding host AC status and causing early scanner termination.
+  - Inspected `type: Mains` and incoming USB-PD chargers (`online: 1`).
+  - Evaluated battery charging status (`Charging`, `Full`, `Not charging` vs `Discharging`).
+  - Recognized desktop workstations and servers without laptop batteries as running on AC power (`󰚥 AC`).
+  - Integrated robust multi-tier power detection in PowerShell (`SystemInformation.PowerStatus` -> `root/wmi:BatteryStatus` -> `Win32_Battery`).
+  - Normalized classic mode rendering in `make_badge` to prevent duplicate `AC AC`.
+  - Added comprehensive automated test suite covering all power supply scenarios with `STATUSLINE_POWER_SUPPLY_DIR` mock harness.
+
 ## [0.2.4] - 2026-09-11
 ### Added & Improved
 - **Vim Editor Mode Indicator (Issue #62)**: Added dynamic Vim mode badge (`NORMAL`, `INSERT`, `VISUAL`, `VISUAL LINE`, fallback) into LINE1 across styled and classic layouts in `statusline.sh` and `statusline.ps1`. Documented in CLI `--legend` and `-Legend`. Participates in responsive width checks to prevent line wrapping.
@@ -26,7 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Uninstallation cleanly restores original `statusLine` or removes only `statusLine` without rolling back unrelated settings added before or after installation. Preserves unknown `statusLine` keys. Preserves symlinks on Linux, macOS, and Windows.
 - **Input Hardening & Version Cleanup (Sections 13, 14)**: Added dynamic string sanitization (stripping newlines, CR, ANSI escapes, control chars). Unified version parsing to `0.2.4`, eliminating stale `v0.2.2`.
 - **Responsive Layout Hardening (Issue #59 / Section 12)**: Hardened LINE1 width gating and truncation across both renderers to guarantee zero uncontrolled line wrapping across terminal widths 60 to 255.
-- **Power & AC Supply Detection Fix (Issue #70)**: Fixed bug where power indicator remained stuck on `🔋 BAT` even when connected to AC power or running on desktop workstations. Excluded peripheral devices (`scope: Device`, `hidpp_*`, mice/keyboards) from overriding host AC status; inspected `type: Mains` and incoming USB chargers; evaluated battery charging status (`Charging`, `Full`, `Not charging` vs `Discharging`); recognized desktop hosts without batteries as AC mains; integrated multi-tier power detection in PowerShell (.NET `PowerStatus` -> `root/wmi:BatteryStatus` -> `Win32_Battery`); normalized classic mode rendering to prevent duplicate `AC AC`.
 
 ## [0.2.3] - 2026-09-03
 ### Added & Improved

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Use these checks when the statusline does not render as expected:
 - **No statusline appears**: confirm that `statusLine.enabled` is `true`, check the command path, and restart Antigravity CLI
 - **Linux or macOS renderer exits**: run `jq --version`; the Bash implementation requires `jq`
 - **Git data is missing**: install Git and confirm the current working directory belongs to a Git repository
-- **Windows Illegal characters in path**: verify your command in `settings.json` does not contain literal escaped quotes around `-File`. The v0.2.4 installer handles spaces automatically using standard path syntax
+- **Windows Illegal characters in path**: verify your command in `settings.json` does not contain literal escaped quotes around `-File`. The v0.2.4+ installer handles spaces automatically using standard path syntax
 - **Windows PowerShell 5.1 font or encoding errors**: `statusline.ps1` includes a UTF-8 BOM to prevent mojibake on non-UTF-8 Windows locales. Ensure the BOM is preserved
 - **A narrow terminal adds more rows**: increase the terminal width or use a layout override (`--compact`, `--medium`) to test a fixed width
 - **Host fields are missing**: the renderer omits diagnostics that the operating system or local tools do not expose

--- a/statusline.ps1
+++ b/statusline.ps1
@@ -8,11 +8,11 @@ $ProgressPreference = 'SilentlyContinue'
 foreach ($arg in $args) {
     $a = if ($arg) { $arg.ToString().ToLower() } else { "" }
     if ($a -in @("--version", "-version", "-v", "version")) {
-        Write-Host "Antigravity CLI Statusline v0.2.4" -ForegroundColor Green
+        Write-Host "Antigravity CLI Statusline v0.2.5" -ForegroundColor Green
         exit
     }
     if ($a -in @("--legend", "-legend", "-l", "legend")) {
-        Write-Host "🚀 Antigravity CLI Statusline Legend (v0.2.4)" -ForegroundColor Green
+        Write-Host "🚀 Antigravity CLI Statusline Legend (v0.2.5)" -ForegroundColor Green
         Write-Host "This statusline adapts dynamically to your terminal width and theme settings.`n"
         
         Write-Host "LAYOUTS:" -ForegroundColor White

--- a/statusline.sh
+++ b/statusline.sh
@@ -10,11 +10,11 @@ CLI_COLS_OVERRIDE=""
 for arg in "$@"; do
   case "$arg" in
     --version|-v)
-      echo "Antigravity CLI Statusline v0.2.4"
+      echo "Antigravity CLI Statusline v0.2.5"
       exit 0
       ;;
     --legend|-l|legend)
-      echo -e "\033[92m\033[1m🚀 Antigravity CLI Maximized Statusline Legend (v0.2.4)\033[0m"
+      echo -e "\033[92m\033[1m🚀 Antigravity CLI Maximized Statusline Legend (v0.2.5)\033[0m"
       echo -e "This statusline adapts dynamically to terminal width and displays high-density system & agent telemetry."
       echo -e ""
       echo -e "\033[1mLAYOUTS & AUTO-PACKING:\033[0m"

--- a/tests/test_bash_renderer.sh
+++ b/tests/test_bash_renderer.sh
@@ -69,7 +69,8 @@ assert_exit_code "$res" 0 "Empty stdin does not crash"
 # Test 2: CLI Flags
 echo "--- Testing CLI Flags ---"
 ver_out=$(bash "$STATUSLINE" --version 2>&1)
-assert_contains "$ver_out" "0.2.4" "Version flag reports 0.2.4"
+assert_contains "$ver_out" "0.2.5" "Version flag reports 0.2.5"
+assert_not_contains "$ver_out" "0.2.4" "Version flag does not contain stale 0.2.4"
 assert_not_contains "$ver_out" "0.2.2" "Version flag does not contain stale 0.2.2"
 legend_out=$(bash "$STATUSLINE" --legend 2>&1)
 assert_contains "$legend_out" "Legend" "Legend flag works"


### PR DESCRIPTION
## Release v0.2.5
This release hardens cross-platform power source detection and bumps the project version to `v0.2.5`.

### What's Changed
- **Power & AC Supply Detection Hardening (Issue #70)**:
  - Resolved bug where the power badge remained stuck on `🔋 BAT` even when connected to external AC mains power or on desktop workstations.
  - Excluded peripheral devices (`scope: Device`, `hidpp_*`, mice, keyboards) from overriding host AC status and causing early scanner termination.
  - Inspected `type: Mains` and incoming USB-PD chargers (`online: 1`).
  - Evaluated battery charging status (`Charging`, `Full`, `Not charging` vs `Discharging`).
  - Recognized desktop workstations and servers without laptop batteries as running on AC power (`󰚥 AC`).
  - Integrated robust multi-tier power detection in PowerShell (`SystemInformation.PowerStatus` -> `root/wmi:BatteryStatus` -> `Win32_Battery`).
  - Normalized classic mode rendering in `make_badge` to prevent duplicate `AC AC`.
  - Added comprehensive automated test suite covering all power supply scenarios with `STATUSLINE_POWER_SUPPLY_DIR` mock harness.

Closes #72


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved power and AC supply detection, including charger inspection, battery charging status, desktop AC detection, and peripheral-device handling.
  - Improved power-status reporting across multiple detection methods and normalized classic-mode badges.

- **Documentation**
  - Updated troubleshooting guidance to apply to v0.2.4 and later installers.

- **Chores**
  - Updated command-line version and legend output to v0.2.5.
  - Added automated coverage for the updated version output and power-detection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->